### PR TITLE
Adjust parameters per model generation

### DIFF
--- a/app.py
+++ b/app.py
@@ -102,8 +102,9 @@ def load_default_user_prompt() -> str:
 
 
 def model_supports_reasoning_and_verbosity(model: str) -> bool:
-    normalized = model.lower()
-    return not normalized.startswith("gpt-4o")
+    """Return True when the model accepts reasoning and verbosity parameters."""
+    normalized = model.lower().strip()
+    return normalized.startswith("gpt-5")
 
 
 def run_model(client: OpenAI, config: RunConfig) -> Dict[str, Any]:
@@ -112,14 +113,20 @@ def run_model(client: OpenAI, config: RunConfig) -> Dict[str, Any]:
     params: Dict[str, Any] = {
         "model": config.model,
         "input": input_messages,
-        "temperature": config.temperature,
-        "top_p": config.top_p,
-        "text": prepare_text_config(config.verbosity if supports_reasoning_and_verbosity else None),
+        "text": prepare_text_config(
+            config.verbosity if supports_reasoning_and_verbosity else None
+        ),
         "store": True,
     }
 
-    if supports_reasoning_and_verbosity and config.reasoning_effort and config.reasoning_effort != "default":
-        params["reasoning"] = {"effort": config.reasoning_effort}
+    if config.top_p is not None:
+        params["top_p"] = config.top_p
+
+    if supports_reasoning_and_verbosity:
+        if config.reasoning_effort and config.reasoning_effort != "default":
+            params["reasoning"] = {"effort": config.reasoning_effort}
+    else:
+        params["temperature"] = config.temperature
 
     response = client.responses.create(**params)
     return response.to_dict()


### PR DESCRIPTION
## Summary
- ensure the top_p sampling parameter is included for GPT-5 series models alongside reasoning-specific options
- continue sending temperature only to GPT-4 models to avoid unsupported parameter errors

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68ca708846888325ac65528ae56dd94c