### PR TITLE
Add prompt cache key to Responses API requests

### DIFF
--- a/app.py
+++ b/app.py
@@ -195,6 +195,7 @@ def run_model(
             config.verbosity if supports_reasoning_and_verbosity else None
         ),
         "store": True,
+        "prompt_cache_key": "isa-poc",
     }
 
     use_file_search_tool = True


### PR DESCRIPTION
## Summary
- include the fixed `prompt_cache_key` value in the Responses API payload so related prompts can reuse cached results

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68d3b2107fa0832586b0ede9169e6d95