### PR TITLE
Simplify conversation controls

### DIFF
--- a/app.py
+++ b/app.py
@@ -409,16 +409,7 @@ def main() -> None:
 
     developer_prompt = load_developer_prompt() or None
 
-    action_col, reset_col = st.columns([3, 1])
-    with action_col:
-        run_button = st.button("Generate responses", type="primary")
-    with reset_col:
-        reset_button = st.button("Start new conversation")
-
-    if reset_button:
-        st.session_state["conversations"] = {}
-        st.session_state["conversation_history"] = {}
-        st.experimental_rerun()
+    run_button = st.button("Generate responses", type="primary")
 
     user_prompt = prompt.strip()
     if run_button:


### PR DESCRIPTION
## Summary
- remove the standalone conversation reset control from the Streamlit UI
- rely on the "Generate responses" button to initiate and continue conversations without triggering deprecated reruns

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6868f15888325917dafeaf5b1e17e