### PR TITLE
Add realtime voice session support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
 streamlit>=1.33.0
 openai>=1.31.1
+streamlit-webrtc>=0.47.7
+av>=11.0.0
+pydub>=0.25.1
+numpy>=1.24.0


### PR DESCRIPTION
## Summary
- add realtime audio dependencies required for streamlit-webrtc and audio processing
- implement helpers, audio processor, and session teardown utilities for realtime voice sessions
- expose UI controls for managing voice conversations and disable text runs while a session is active

## Testing
- python -m py_compile app.py

------
https://chatgpt.com/codex/tasks/task_e_68de357561f08325a788f7fccebfdf7d